### PR TITLE
Adds function to apply Eq 46 from Gumerov paper

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 add_catch_test(translation_addition LIBRARIES optilib ${library_dependencies})
 add_catch_test(harmonics_iterator LIBRARIES optilib ${library_dependencies})
 add_catch_test(aux_coefficients LIBRARIES optilib ${library_dependencies})
+add_catch_test(rotation_coaxial_decomposition LIBRARIES optilib ${library_dependencies})
 
 add_catch_test(rotation_coefficients LIBRARIES optilib ${library_dependencies})
 

--- a/unittests/rotation_coaxial_decomposition.cpp
+++ b/unittests/rotation_coaxial_decomposition.cpp
@@ -10,53 +10,54 @@ using namespace optimet;
 TEST_CASE("Brute check") {
   using optimet::coefficient::a;
   auto const nmax = 4;
-  Matrix<t_complex> input = Matrix<t_complex>::Zero(nmax * (nmax + 2), 2);
+  Matrix<t_complex> input((nmax + 1) * (nmax + 1), 2);
+  input.fill(0);
   SECTION("Nothing in n±1") {
     SECTION("n=1") {
-      input(0, 0) = 2;
-      input(0, 1) = t_complex(0, 1);
+      input(1, 0) = 2;
+      input(1, 1) = t_complex(0, 1);
 
       for(auto const k: {1.0, 1.5}) {
         auto out = rotation_coaxial_decomposition(k, 2, input);
-        CHECK(out(0, 0).real() == Approx(2 + k * k));
-        CHECK(out(0, 0).imag() == Approx(0));
-        CHECK(out(0, 1).real() == Approx(0));
-        CHECK(out(0, 1).imag() == Approx(-1));
+        CHECK(out(1, 0).real() == Approx(2 + k * k));
+        CHECK(out(1, 0).imag() == Approx(0));
+        CHECK(out(1, 1).real() == Approx(0));
+        CHECK(out(1, 1).imag() == Approx(-1));
       }
     }
     SECTION("n=2") {
-      input(3, 0) = 2;
-      input(3, 1) = t_complex(0, 1);
+      input(4, 0) = 2;
+      input(4, 1) = t_complex(0, 1);
 
       auto out = rotation_coaxial_decomposition(1, 6, input);
-      CHECK(out(3, 0).real() == Approx(4));
-      CHECK(out(3, 0).imag() == Approx(0));
-      CHECK(out(3, 1).real() == Approx(0));
-      CHECK(out(3, 1).imag() == Approx(-3));
+      CHECK(out(4, 0).real() == Approx(4));
+      CHECK(out(4, 0).imag() == Approx(0));
+      CHECK(out(4, 1).real() == Approx(0));
+      CHECK(out(4, 1).imag() == Approx(-3));
     }
   }
 
   SECTION("Something in n - 1") {
-    input(0, 0) = 2;
-    input(0, 1) = t_complex(0, 1);
+    input(1, 0) = 2;
+    input(1, 1) = t_complex(0, 1);
 
     auto out = rotation_coaxial_decomposition(1, 6, input);
-    CHECK(out(4, 0).real() == Approx(3 * a<>(1, -1) * 2));
-    CHECK(out(4, 0).imag() == Approx(0));
-    CHECK(out(4, 1).real() == Approx(0));
-    CHECK(out(4, 1).imag() == Approx(3 * a<>(1, -1)));
+    CHECK(out(5, 0).real() == Approx(3 * a<>(1, -1) * 2));
+    CHECK(out(5, 0).imag() == Approx(0));
+    CHECK(out(5, 1).real() == Approx(0));
+    CHECK(out(5, 1).imag() == Approx(3 * a<>(1, -1)));
   }
 
   SECTION("Something in n + 1") {
-    input(4, 0) = 2;
-    input(4, 1) = t_complex(0, 1);
+    input(5, 0) = 2;
+    input(5, 1) = t_complex(0, 1);
 
     for(auto const k: {1.0, 1.5}) {
       auto out = rotation_coaxial_decomposition(k, 2, input);
-      CHECK(out(0, 0).real() == Approx(a<>(1, -1) * 2 * k));
-      CHECK(out(0, 0).imag() == Approx(0));
-      CHECK(out(0, 1).real() == Approx(0));
-      CHECK(out(0, 1).imag() == Approx(a<>(1, -1) * k));
+      CHECK(out(1, 0).real() == Approx(a<>(1, -1) * 2 * k));
+      CHECK(out(1, 0).imag() == Approx(0));
+      CHECK(out(1, 1).real() == Approx(0));
+      CHECK(out(1, 1).imag() == Approx(a<>(1, -1) * k));
     }
   }
 }


### PR DESCRIPTION
That's doi: 10.1137/S1064827501399705.

Rather than go for a sparse matrix, I've directly created a function to
apply the matrix to a two-column matrix containing the vector potentials
(Φ, Ψ). This is easier since the two columns of the matrix will not be
contiguous in practice. So viewing the operation as a sparse matrix
times a dense contiguous vector is not possible.

@jenshnielsen, all yours
